### PR TITLE
Add --realtime-bar-target parameter to tutorial

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -53,7 +53,7 @@ Enable API Clients in Configuration API/Settings by setting 'Enable ActiveX and 
 ## Run!
 Start zipline-live with `--broker` and `--broker-uri` specified.
 ```
-zipline run -f ~/zipline-algos/demo.py --state-file ~/zipline-algos/demo.state --broker ib --broker-uri localhost:7496:1232 --bundle quantopian-quandl  --data-frequency minute
+zipline run -f ~/zipline-algos/demo.py --state-file ~/zipline-algos/demo.state --realtime-bar-target ~/zipline-algos/realtime-bars/ --broker ib --broker-uri localhost:7496:1232 --bundle quantopian-quandl --data-frequency minute
 ```
 ```
 [2017-08-18 15:07:24.850838] INFO: IB Broker: Connecting: localhost:7496:1232


### PR DESCRIPTION
Documents the newly added (and required) command line parameter from here:
https://github.com/zipline-live/zipline/commit/094018e10afdc637d1c7eca3edb0d767a0f6f4ce
